### PR TITLE
fix: remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "scroll into view polyfill"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=16"
-  },
   "main": "./dist/scroll.common.js",
   "module": "./dist/scroll.js",
   "types": "./dist/scroll.d.ts",


### PR DESCRIPTION
As discussed in #417 this package does not need the engine field. This PR gets rid of it.